### PR TITLE
Event dot colorization 

### DIFF
--- a/FSCalendar/FSCalendar.h
+++ b/FSCalendar/FSCalendar.h
@@ -44,6 +44,7 @@ typedef NS_ENUM(NSUInteger, FSCalendarUnit) {
 - (NSDate *)minimumDateForCalendar:(FSCalendar *)calendar;
 - (NSDate *)maximumDateForCalendar:(FSCalendar *)calendar;
 - (NSInteger)calendar:(FSCalendar *)calendar numberOfEventsForDate:(NSDate *)date;
+- (NSArray *)calendar:(FSCalendar *)calendar colorsForEventsForDate:(NSDate *)date;
 
 - (BOOL)calendar:(FSCalendar *)calendar hasEventForDate:(NSDate *)date FSCalendarDeprecated(-calendar:numberOfEventsForDate:);
 

--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -26,6 +26,7 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
 @interface FSCalendar (DataSourceAndDelegate)
 
 - (NSInteger)numberOfEventsForDate:(NSDate *)date;
+- (NSArray *)colorsForEventsForDate:(NSDate *)date;
 - (NSString *)subtitleForDate:(NSDate *)date;
 - (UIImage *)imageForDate:(NSDate *)date;
 - (NSDate *)minimumDateForCalendar;
@@ -1519,6 +1520,7 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
     cell.date = [self dateForIndexPath:indexPath];
     cell.image = [self imageForDate:cell.date];
     cell.numberOfEvents = [self numberOfEventsForDate:cell.date];
+    cell.colorsForEvents = [self colorsForEventsForDate:cell.date];
     cell.subtitle  = [self subtitleForDate:cell.date];
     cell.dateIsSelected = [_selectedDates containsObject:cell.date];
     cell.dateIsToday = [self isDateInToday:cell.date];
@@ -1850,6 +1852,14 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
 #endif
     return 0;
     
+}
+
+- (NSArray *)colorsForEventsForDate:(NSDate *)date
+{
+    if (_dataSource && [_dataSource respondsToSelector:@selector(calendar:colorsForEventsForDate:)]) {
+        return [_dataSource calendar:self colorsForEventsForDate:date];
+    }
+    return nil;
 }
 
 - (NSDate *)minimumDateForCalendar

--- a/FSCalendar/FSCalendarCell.h
+++ b/FSCalendar/FSCalendarCell.h
@@ -28,6 +28,7 @@
 
 @property (assign, nonatomic) BOOL needsAdjustingViewFrame;
 @property (assign, nonatomic) NSInteger numberOfEvents;
+@property (strong, nonatomic) NSArray *colorsForEvents;
 
 @property (assign, nonatomic) BOOL dateIsPlaceholder;
 @property (assign, nonatomic) BOOL dateIsSelected;

--- a/FSCalendar/FSCalendarCell.m
+++ b/FSCalendar/FSCalendarCell.m
@@ -222,6 +222,7 @@
     }
     _eventIndicator.numberOfEvents = self.numberOfEvents;
     _eventIndicator.color = self.preferredEventColor ?: _appearance.eventColor;
+    _eventIndicator.colors = self.colorsForEvents;
 }
 
 - (BOOL)isWeekend
@@ -282,6 +283,7 @@
 - (void)invalidateEventColors
 {
     _eventIndicator.color = self.preferredEventColor ?: _appearance.eventColor;
+    _eventIndicator.colors = nil;
 }
 
 - (void)invalidateCellShapes

--- a/FSCalendar/FSCalendarEventIndicator.h
+++ b/FSCalendar/FSCalendarEventIndicator.h
@@ -12,6 +12,7 @@
 
 @property (assign, nonatomic) NSInteger numberOfEvents;
 @property (strong, nonatomic) UIColor *color;
+@property (strong, nonatomic) NSArray *colors;
 @property (assign, nonatomic) BOOL needsAdjustingViewFrame;
 
 @end

--- a/FSCalendar/FSCalendarEventIndicator.m
+++ b/FSCalendar/FSCalendarEventIndicator.m
@@ -79,8 +79,13 @@
         if (_needsInvalidatingColor) {
             _needsInvalidatingColor = NO;
             CGFloat diameter = MIN(MIN(self.fs_width, self.fs_height),FSCalendarMaximumEventDotDiameter);
-            UIImage *dotImage = [self dotImageWithColor:_color diameter:diameter];
-            [self.eventLayers makeObjectsPerformSelector:@selector(setContents:) withObject:(id)dotImage.CGImage];
+            
+            for (int i = 0; i < self.numberOfEvents; i++) {
+                UIColor *colorToSet = _colors[i] != nil ? _colors[i] : _color;
+                UIImage *dotImage = [self dotImageWithColor:colorToSet diameter:diameter];
+                CALayer *layer = self.eventLayers[i];
+                [layer setContents:(id)dotImage.CGImage];
+            }
         }
     }
 }
@@ -89,6 +94,15 @@
 {
     if (![_color isEqual:color]) {
         _color = color;
+        _needsInvalidatingColor = YES;
+        [self setNeedsLayout];
+    }
+}
+
+- (void)setColors:(NSArray *)colors
+{
+    if (![_colors isEqual:colors]) {
+        _colors = colors;
         _needsInvalidatingColor = YES;
         [self setNeedsLayout];
     }


### PR DESCRIPTION
I added a way to colorize each event dot, I'm not sure if this is the best option, but it gives the most flexibility I think. 

```
func calendar(calendar: FSCalendar!, numberOfEventsForDate date: NSDate!) -> Int {
    return 2
}
    
func calendar(calendar: FSCalendar!, colorsForEventsForDate date: NSDate!) -> [AnyObject]! {
    return [UIColor.redColor(), UIColor.greenColor()]
}
```
I tried to match the code style as best as I could. Using _ for iVars is weird to me, I usually use self.var so if I missed any, let me know and ill fix it