### PR TITLE
Removing unnecessary import

### DIFF
--- a/FSCalendar/FSCalendarCollectionView.m
+++ b/FSCalendar/FSCalendarCollectionView.m
@@ -7,7 +7,6 @@
 //
 
 #import "FSCalendarCollectionView.h"
-#import "FSCalendarCell.h"
 
 @interface FSCalendarCollectionView ()
 


### PR DESCRIPTION
I've noticed this import is not necessary.

---

I'm also curious why did you need to subclass collection view and to override these methods? Commit (https://github.com/WenchaoD/FSCalendar/commit/12e184abded3812bec919a24a86c9ffd4df5421e) message says:

> Subclass UICollectionView to turn off system action for UIScrollView

Any chance you remember what would be repro steps to see the issue? Thanks in advance :)