### PR TITLE
Fix Out of Bounds when minimumDateForCalendar

### DIFF
--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -2142,6 +2142,9 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
     if (!_hasRequestedBoundingDates) {
         _hasRequestedBoundingDates = YES;
         _minimumDate = self.minimumDateForCalendar;
+        if ([_minimumDate compare:_currentPage] == NSOrderedDescending) {
+            _currentPage = [self beginingOfMonth:_minimumDate];
+        }
         _maximumDate = self.maximumDateForCalendar;
     }
 }


### PR DESCRIPTION
If the calendar has a `minimumDateForCalendar` set the default  `currentPage` to `minimumDate` instead of `today`of `today` is before `minimumDate`

Fix issue https://github.com/WenchaoD/FSCalendar/issues/450
