### PR TITLE
New allowsSelectionFromAllMonthsInWeekScope property

### DIFF
--- a/FSCalendar/FSCalendar.h
+++ b/FSCalendar/FSCalendar.h
@@ -412,6 +412,11 @@ IB_DESIGNABLE
 @property (assign, nonatomic) IBInspectable BOOL showsScopeHandle FSCalendarDeprecated(handleScopeGesture:);
 
 /**
+ A Boolean value that determines whether the calendar should allow selection of days from previous and next months when showing week scope. Default is NO;
+ */
+@property (assign, nonatomic) IBInspectable BOOL allowsSelectionFromAllMonthsInWeekScope;
+
+/**
  The multiplier of line height while paging enabled is NO. Default is 1.0;
  */
 @property (assign, nonatomic) IBInspectable CGFloat lineHeightMultiplier;

--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -519,7 +519,7 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
 - (BOOL)collectionView:(UICollectionView *)collectionView shouldSelectItemAtIndexPath:(NSIndexPath *)indexPath
 {
     FSCalendarMonthPosition monthPosition = [self.calculator monthPositionForIndexPath:indexPath];
-    if (self.placeholderType == FSCalendarPlaceholderTypeNone && monthPosition != FSCalendarMonthPositionCurrent) {
+    if ((self.placeholderType == FSCalendarPlaceholderTypeNone && monthPosition != FSCalendarMonthPositionCurrent) && !self.allowsSelectionFromAllMonthsInWeekScope) {
         return NO;
     }
     NSDate *date = [self.calculator dateForIndexPath:indexPath];


### PR DESCRIPTION
This property let user select whether the previous or next month dates should be allowed to select when calendar is showing week scope.