### PR TITLE
Make selectedDate nullable

### DIFF
--- a/FSCalendar/FSCalendar.h
+++ b/FSCalendar/FSCalendar.h
@@ -417,7 +417,7 @@ IB_DESIGNABLE
 /**
  A date object identifying the section of the selected date. (read-only)
  */
-@property (readonly, nonatomic) NSDate *selectedDate;
+@property (nullable, readonly, nonatomic) NSDate *selectedDate;
 
 /**
  The dates representing the selected dates. (read-only)


### PR DESCRIPTION
We were encountering a crash when using FSCalendar in a Swift app. Upon accessing the property it was being force unwrapped since it was not marked nullable.

Marking it as nullable enables the property to be nil (which it can be).