### PR TITLE
Fix analyzer issue

### DIFF
--- a/Example-Swift/FSCalendarSwiftExample/DIYCalendarCell.swift
+++ b/Example-Swift/FSCalendarSwiftExample/DIYCalendarCell.swift
@@ -78,7 +78,8 @@ class DIYCalendarCell: FSCalendarCell {
     
     override func configureAppearance() {
         super.configureAppearance()
-        // Override the build-in appearance configuration
+		
+        // Override the built-in appearance configuration
         if self.isPlaceholder {
             self.eventIndicator.isHidden = true
             self.titleLabel.textColor = UIColor.lightGray

--- a/FSCalendar/FSCalendarWeekdayView.m
+++ b/FSCalendar/FSCalendarWeekdayView.m
@@ -66,7 +66,7 @@
     NSInteger count = self.weekdayPointers.count;
     size_t size = sizeof(CGFloat)*count;
     CGFloat *widths = calloc(size, sizeof(CGFloat));
-	CGFloat contentWidth = self.contentView.fs_width;
+    CGFloat contentWidth = self.contentView.fs_width;
     FSCalendarSliceCake(contentWidth, count, widths);
     
     __block CGFloat x = 0;
@@ -105,7 +105,7 @@
         label.textColor = self.calendar.appearance.weekdayTextColor;
         label.text = useDefaultWeekdayCase ? weekdaySymbols[index] : [weekdaySymbols[index] uppercaseString];
     }
-
+    
 }
 
 @end

--- a/FSCalendar/FSCalendarWeekdayView.m
+++ b/FSCalendar/FSCalendarWeekdayView.m
@@ -65,8 +65,8 @@
     // Position Calculation
     NSInteger count = self.weekdayPointers.count;
     size_t size = sizeof(CGFloat)*count;
-    CGFloat *widths = malloc(size);
-    CGFloat contentWidth = self.contentView.fs_width;
+    CGFloat *widths = calloc(size, sizeof(CGFloat));
+	CGFloat contentWidth = self.contentView.fs_width;
     FSCalendarSliceCake(contentWidth, count, widths);
     
     __block CGFloat x = 0;


### PR DESCRIPTION
Code to address analyzer issue being thrown up by Xcode when `Product > Analyze` was run on the `FSCalendarSwiftExample` project.

![analyzer issue - fscalendar](https://cloud.githubusercontent.com/assets/337963/25073747/efafc6e2-22ba-11e7-8e7c-f9026133f6b0.png)

Using `calloc` instead of `malloc` here corrects the issue, as `calloc` initializes the memory allocated immediately.