### PR TITLE
Correct analyzer warning

### DIFF
--- a/FSCalendar/FSCalendarWeekdayView.m
+++ b/FSCalendar/FSCalendarWeekdayView.m
@@ -63,7 +63,7 @@
     self.contentView.frame = self.bounds;
     
     // Position Calculation
-    NSInteger count = self.weekdayPointers.allObjects.count;
+    NSInteger count = self.weekdayPointers.count;
     size_t size = sizeof(CGFloat)*count;
     CGFloat *widths = malloc(size);
     CGFloat contentWidth = self.contentView.fs_width;

--- a/FSCalendar/FSCalendarWeekdayView.m
+++ b/FSCalendar/FSCalendarWeekdayView.m
@@ -63,14 +63,14 @@
     self.contentView.frame = self.bounds;
     
     // Position Calculation
-    NSInteger count = self.weekdayPointers.count;
+    NSInteger count = self.weekdayPointers.allObjects.count;
     size_t size = sizeof(CGFloat)*count;
     CGFloat *widths = malloc(size);
     CGFloat contentWidth = self.contentView.fs_width;
     FSCalendarSliceCake(contentWidth, count, widths);
     
     __block CGFloat x = 0;
-    for (NSInteger i = 0; i < self.weekdayPointers.count; i++) {
+    for (NSInteger i = 0; i < count; i++) {
         CGFloat width = widths[i];
         UILabel *label = [self.weekdayPointers pointerAtIndex:i];
         label.frame = CGRectMake(x, 0, width, self.contentView.fs_height);


### PR DESCRIPTION
Code to address analyzer issue being thrown up by Xcode when Product > Analyze was run on the FSCalendarSwiftExample project.

![analyzer-issue](https://cloud.githubusercontent.com/assets/337963/25095555/31f08fc8-236a-11e7-8a85-f07cd586da2a.png)


Original solution was discussed in https://github.com/WenchaoD/FSCalendar/pull/648; but feel like this solution is even better than the ones discussed on that thread. Thoughts welcomed !