### PR TITLE
Add 'days in week' constant

### DIFF
--- a/Example-Swift/FSCalendarSwiftExample/DIYCalendarCell.swift
+++ b/Example-Swift/FSCalendarSwiftExample/DIYCalendarCell.swift
@@ -78,7 +78,8 @@ class DIYCalendarCell: FSCalendarCell {
     
     override func configureAppearance() {
         super.configureAppearance()
-        // Override the build-in appearance configuration
+		
+        // Override the built-in appearance configuration
         if self.isPlaceholder {
             self.eventIndicator.isHidden = true
             self.titleLabel.textColor = UIColor.lightGray

--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -444,17 +444,17 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
 {
     if (self.floatingMode) {
         NSInteger numberOfRows = [self.calculator numberOfRowsInSection:section];
-        return numberOfRows * 7;
+        return numberOfRows * FSCalendarNumberOfDaysInWeek;
     }
     switch (self.transitionCoordinator.representingScope) {
         case FSCalendarScopeMonth: {
             return 42;
         }
         case FSCalendarScopeWeek: {
-            return 7;
+            return FSCalendarNumberOfDaysInWeek;
         }
     }
-    return 7;
+    return FSCalendarNumberOfDaysInWeek;
 }
 
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath
@@ -470,7 +470,7 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
         }
         case FSCalendarPlaceholderTypeFillHeadTail: {
             if (self.transitionCoordinator.representingScope == FSCalendarScopeMonth) {
-                if (indexPath.item >= 7 * [self.calculator numberOfRowsInSection:indexPath.section]) {
+                if (indexPath.item >= FSCalendarNumberOfDaysInWeek * [self.calculator numberOfRowsInSection:indexPath.section]) {
                     return [collectionView dequeueReusableCellWithReuseIdentifier:FSCalendarBlankCellReuseIdentifier forIndexPath:indexPath];
                 }
             }

--- a/FSCalendar/FSCalendarCalculator.m
+++ b/FSCalendar/FSCalendarCalculator.m
@@ -149,7 +149,7 @@
         }
         case FSCalendarScopeWeek: {
             section = [self.gregorian components:NSCalendarUnitWeekOfYear fromDate:[self.gregorian fs_firstDayOfWeek:self.minimumDate] toDate:[self.gregorian fs_firstDayOfWeek:date] options:0].weekOfYear;
-            item = (([self.gregorian component:NSCalendarUnitWeekday fromDate:date] - self.gregorian.firstWeekday) + 7) % 7;
+            item = (([self.gregorian component:NSCalendarUnitWeekday fromDate:date] - self.gregorian.firstWeekday) + FSCalendarNumberOfDaysInWeek) % FSCalendarNumberOfDaysInWeek;
             break;
         }
     }
@@ -235,7 +235,7 @@
 - (NSInteger)numberOfHeadPlaceholdersForMonth:(NSDate *)month
 {
     NSInteger currentWeekday = [self.gregorian component:NSCalendarUnitWeekday fromDate:month];
-    NSInteger number = ((currentWeekday- self.gregorian.firstWeekday) + 7) % 7 ?: (7 * (!self.calendar.floatingMode&&(self.calendar.placeholderType == FSCalendarPlaceholderTypeFillSixRows)));
+    NSInteger number = ((currentWeekday- self.gregorian.firstWeekday) + FSCalendarNumberOfDaysInWeek) % FSCalendarNumberOfDaysInWeek ?: (7 * (!self.calendar.floatingMode&&(self.calendar.placeholderType == FSCalendarPlaceholderTypeFillSixRows)));
     return number;
 }
 
@@ -249,7 +249,7 @@
         NSDate *firstDayOfMonth = [self.gregorian fs_firstDayOfMonth:month];
         NSInteger weekdayOfFirstDay = [self.gregorian component:NSCalendarUnitWeekday fromDate:firstDayOfMonth];
         NSInteger numberOfDaysInMonth = [self.gregorian fs_numberOfDaysInMonth:month];
-        NSInteger numberOfPlaceholdersForPrev = ((weekdayOfFirstDay - self.gregorian.firstWeekday) + 7) % 7;
+        NSInteger numberOfPlaceholdersForPrev = ((weekdayOfFirstDay - self.gregorian.firstWeekday) + FSCalendarNumberOfDaysInWeek) % FSCalendarNumberOfDaysInWeek;
         NSInteger headDayCount = numberOfDaysInMonth + numberOfPlaceholdersForPrev;
         NSInteger numberOfRows = (headDayCount/7) + (headDayCount%7>0);
         rowCount = @(numberOfRows);
@@ -287,8 +287,8 @@
 - (FSCalendarCoordinate)coordinateForIndexPath:(NSIndexPath *)indexPath
 {
     FSCalendarCoordinate coordinate;
-    coordinate.row = indexPath.item / 7;
-    coordinate.column = indexPath.item % 7;
+    coordinate.row = indexPath.item / FSCalendarNumberOfDaysInWeek;
+    coordinate.column = indexPath.item % FSCalendarNumberOfDaysInWeek;
     return coordinate;
 }
 

--- a/FSCalendar/FSCalendarCollectionViewLayout.m
+++ b/FSCalendar/FSCalendarCollectionViewLayout.m
@@ -140,7 +140,7 @@
     // Calculate item widths and lefts
     free(self.widths);
     self.widths = ({
-        NSInteger columnCount = 7;
+        NSInteger columnCount = FSCalendarNumberOfDaysInWeek;
         size_t columnSize = sizeof(CGFloat)*columnCount;
         CGFloat *widths = malloc(columnSize);
         CGFloat contentWidth = self.collectionView.fs_width - self.sectionInsets.left - self.sectionInsets.right;
@@ -150,7 +150,7 @@
     
     free(self.lefts);
     self.lefts = ({
-        NSInteger columnCount = 7;
+        NSInteger columnCount = FSCalendarNumberOfDaysInWeek;
         size_t columnSize = sizeof(CGFloat)*columnCount;
         CGFloat *lefts = malloc(columnSize);
         lefts[0] = self.sectionInsets.left;
@@ -290,8 +290,8 @@
                 
                 for (NSInteger column = startColumn; column <= endColumn; column++) {
                     for (NSInteger row = 0; row < numberOfRows; row++) {
-                        NSInteger section = column / 7;
-                        NSInteger item = column % 7 + row * 7;
+                        NSInteger section = column / FSCalendarNumberOfDaysInWeek;
+                        NSInteger item = column % FSCalendarNumberOfDaysInWeek + row * FSCalendarNumberOfDaysInWeek;
                         NSIndexPath *indexPath = [NSIndexPath indexPathForItem:item inSection:section];
                         UICollectionViewLayoutAttributes *itemAttributes = [self layoutAttributesForItemAtIndexPath:indexPath];
                         [layoutAttributes addObject:itemAttributes];
@@ -331,9 +331,9 @@
                 });
                 
                 for (NSInteger row = startRow; row <= endRow; row++) {
-                    for (NSInteger column = 0; column < 7; column++) {
+                    for (NSInteger column = 0; column < FSCalendarNumberOfDaysInWeek; column++) {
                         NSInteger section = row / 6;
-                        NSInteger item = column + (row % 6) * 7;
+                        NSInteger item = column + (row % 6) * FSCalendarNumberOfDaysInWeek;
                         NSIndexPath *indexPath = [NSIndexPath indexPathForItem:item inSection:section];
                         UICollectionViewLayoutAttributes *itemAttributes = [self layoutAttributesForItemAtIndexPath:indexPath];
                         [layoutAttributes addObject:itemAttributes];
@@ -375,8 +375,8 @@
             UICollectionViewLayoutAttributes *headerAttributes = [self layoutAttributesForSupplementaryViewOfKind:UICollectionElementKindSectionHeader atIndexPath:[NSIndexPath indexPathForItem:0 inSection:section]];
             [layoutAttributes addObject:headerAttributes];
             for (NSInteger row = startRow; row <= endRow; row++) {
-                for (NSInteger column = 0; column < 7; column++) {
-                    NSInteger item = row * 7 + column;
+                for (NSInteger column = 0; column < FSCalendarNumberOfDaysInWeek; column++) {
+                    NSInteger item = row * FSCalendarNumberOfDaysInWeek + column;
                     NSIndexPath *indexPath = [NSIndexPath indexPathForItem:item inSection:section];
                     UICollectionViewLayoutAttributes *itemAttributes = [self layoutAttributesForItemAtIndexPath:indexPath];
                     [layoutAttributes addObject:itemAttributes];

--- a/FSCalendar/FSCalendarConstants.h
+++ b/FSCalendar/FSCalendarConstants.h
@@ -1,5 +1,5 @@
 //
-//  FSCalendarConstane.h
+//  FSCalendarConstants.h
 //  FSCalendar
 //
 //  Created by dingwenchao on 8/28/15.
@@ -29,6 +29,7 @@ CG_EXTERN CGFloat const FSCalendarStandardHeaderTextSize;
 CG_EXTERN CGFloat const FSCalendarMaximumEventDotDiameter;
 CG_EXTERN CGFloat const FSCalendarStandardScopeHandleHeight;
 
+UIKIT_EXTERN NSInteger const FSCalendarNumberOfDaysInWeek;
 UIKIT_EXTERN NSInteger const FSCalendarDefaultHourComponent;
 
 UIKIT_EXTERN NSString * const FSCalendarDefaultCellReuseIdentifier;
@@ -97,6 +98,8 @@ static inline void FSCalendarSliceCake(CGFloat cake, NSInteger count, CGFloat *p
         pieces[i] = piece;
     }
 }
+
+
 
 
 

--- a/FSCalendar/FSCalendarConstants.m
+++ b/FSCalendar/FSCalendarConstants.m
@@ -1,5 +1,5 @@
 //
-//  FSCalendarConstane.m
+//  FSCalendarConstants.m
 //  FSCalendar
 //
 //  Created by dingwenchao on 8/28/15.
@@ -26,6 +26,7 @@ CGFloat const FSCalendarStandardHeaderTextSize = 16.5;
 CGFloat const FSCalendarMaximumEventDotDiameter = 4.8;
 CGFloat const FSCalendarStandardScopeHandleHeight = 26;
 
+NSInteger const FSCalendarNumberOfDaysInWeek = 7;
 NSInteger const FSCalendarDefaultHourComponent = 0;
 
 NSString * const FSCalendarDefaultCellReuseIdentifier = @"_FSCalendarDefaultCellReuseIdentifier";

--- a/FSCalendar/FSCalendarExtensions.m
+++ b/FSCalendar/FSCalendarExtensions.m
@@ -7,6 +7,7 @@
 //
 
 #import "FSCalendarExtensions.h"
+#import "FSCalendarConstants.h"
 #import <objc/runtime.h>
 
 @implementation UIView (FSCalendarExtensions)
@@ -169,7 +170,7 @@
     NSDateComponents *weekdayComponents = [self components:NSCalendarUnitWeekday fromDate:week];
     NSDateComponents *components = self.fs_privateComponents;
     components.day = - (weekdayComponents.weekday - self.firstWeekday);
-    components.day = (components.day-7) % 7;
+    components.day = (components.day-7) % FSCalendarNumberOfDaysInWeek;
     NSDate *firstDayOfWeek = [self dateByAddingComponents:components toDate:week options:0];
     firstDayOfWeek = [self dateBySettingHour:0 minute:0 second:0 ofDate:firstDayOfWeek options:0];
     components.day = NSIntegerMax;
@@ -182,7 +183,7 @@
     NSDateComponents *weekdayComponents = [self components:NSCalendarUnitWeekday fromDate:week];
     NSDateComponents *components = self.fs_privateComponents;
     components.day = - (weekdayComponents.weekday - self.firstWeekday);
-    components.day = (components.day-7) % 7 + 6;
+    components.day = (components.day-7) % FSCalendarNumberOfDaysInWeek + 6;
     NSDate *lastDayOfWeek = [self dateByAddingComponents:components toDate:week options:0];
     lastDayOfWeek = [self dateBySettingHour:0 minute:0 second:0 ofDate:lastDayOfWeek options:0];
     components.day = NSIntegerMax;

--- a/FSCalendar/FSCalendarWeekdayView.m
+++ b/FSCalendar/FSCalendarWeekdayView.m
@@ -48,7 +48,7 @@
     _contentView = contentView;
     
     _weekdayPointers = [NSPointerArray weakObjectsPointerArray];
-    for (int i = 0; i < 7; i++) {
+    for (int i = 0; i < FSCalendarNumberOfDaysInWeek; i++) {
         UILabel *weekdayLabel = [[UILabel alloc] initWithFrame:CGRectZero];
         weekdayLabel.textAlignment = NSTextAlignmentCenter;
         [self.contentView addSubview:weekdayLabel];
@@ -99,7 +99,7 @@
     BOOL useDefaultWeekdayCase = (self.calendar.appearance.caseOptions & (15<<4) ) == FSCalendarCaseOptionsWeekdayUsesDefaultCase;
     
     for (NSInteger i = 0; i < self.weekdayPointers.count; i++) {
-        NSInteger index = (i + self.calendar.firstWeekday-1) % 7;
+        NSInteger index = (i + self.calendar.firstWeekday-1) % FSCalendarNumberOfDaysInWeek;
         UILabel *label = [self.weekdayPointers pointerAtIndex:index];
         label.font = self.calendar.appearance.weekdayFont;
         label.textColor = self.calendar.appearance.weekdayTextColor;

--- a/FSCalendar/FSCalendarWeekdayView.m
+++ b/FSCalendar/FSCalendarWeekdayView.m
@@ -14,8 +14,8 @@
 @interface FSCalendarWeekdayView()
 
 @property (strong, nonatomic) NSPointerArray *weekdayPointers;
-@property (weak  , nonatomic) UIView *contentView;
-@property (weak  , nonatomic) FSCalendar *calendar;
+@property (weak, nonatomic) UIView *contentView;
+@property (weak, nonatomic) FSCalendar *calendar;
 
 - (void)commonInit;
 


### PR DESCRIPTION
Added constant `FSCalendarNumberOfDaysInWeek` for use in place of `7` throughout codebase, improving readability.

Originally discussed as part of https://github.com/WenchaoD/FSCalendar/pull/648.
