### PR TITLE
Fix for #680 - Fails to build for non-LP64 (iPhone 4s) due to implicit float-to-double conversion

### DIFF
--- a/FSCalendar/FSCalendarConstants.h
+++ b/FSCalendar/FSCalendarConstants.h
@@ -91,8 +91,7 @@ typedef NS_ENUM(NSUInteger, FSCalendarUnit) {
 static inline void FSCalendarSliceCake(CGFloat cake, NSInteger count, CGFloat *pieces) {
     CGFloat total = cake;
     for (int i = 0; i < count; i++) {
-        NSInteger remains = count - i;
-        CGFloat piece = FSCalendarRound(total/remains*2)*0.5;
+        CGFloat piece = FSCalendarRound(total / (count - i));
         total -= piece;
         pieces[i] = piece;
     }


### PR DESCRIPTION
When building for iPhone 4s, the `FSCalendarRound()` expression returns a float while the  `0.5` constant is a double, resulting in an “implicit conversion” warning. (Imported as a CocoaPod, this creates a build failure if the host project has `CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION` and `GCC_TREAT_WARNINGS_AS_ERRORS`.)

Rewriting the multiply-by-half (double) as a divide-by-two (integer), or writing the constant as `0.5f`, resolves the warning. However, the whole expression features redundant arithmetic (a division by two followed by a multiplication by two) whose purpose is not obvious. Therefore, I have simplified the expression, to no apparent ill effect.

Note: with `CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION` enabled, the rest of the project emits a great number of other conversion warnings. These are not yet addressed here; this one site appears to be the sole contaminant when importing via CocoaPods.