### PR TITLE
Implemented delegate called when page scrolling completed.

### DIFF
--- a/FSCalendar/FSCalendar.h
+++ b/FSCalendar/FSCalendar.h
@@ -154,6 +154,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)calendarCurrentPageDidChange:(FSCalendar *)calendar;
 
 /**
+ Tells the delegate the calendar has finished the scroll animation.
+ */
+- (void)calendarCurrentPageDidScroll:(FSCalendar *)calendar;
+
+/**
  These functions are deprecated
  */
 - (void)calendarCurrentScopeWillChange:(FSCalendar *)calendar animated:(BOOL)animated FSCalendarDeprecated(-calendar:boundingRectWillChange:animated:);

--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -696,6 +696,9 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
             obj.enabled = YES;
         }
     }];
+
+    [self.delegateProxy calendarCurrentPageDidScroll:self];
+
 }
 
 #pragma mark - <UIGestureRecognizerDelegate>


### PR DESCRIPTION
I wanted a delegate to be called when the animation for scrolling completed. calendarCurrentPageDidChange is currently called before the animation occurs. Going through the issue tracker, this feature has been requested a few times.