### PR TITLE
Add replacement from month names to standalone month names

### DIFF
--- a/FSCalendar/FSCalendarExtensions.h
+++ b/FSCalendar/FSCalendarExtensions.h
@@ -46,6 +46,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSDate *)fs_middleDayOfWeek:(NSDate *)week;
 - (NSInteger)fs_numberOfDaysInMonth:(NSDate *)month;
 
+- (NSString *)replaceMonthNameWithStandaloneInText:(NSString *)text withFormat:(NSString *)format;
+
 @end
 
 @interface NSMapTable (FSCalendarExtensions)

--- a/FSCalendar/FSCalendarExtensions.m
+++ b/FSCalendar/FSCalendarExtensions.m
@@ -221,6 +221,50 @@
     return components;
 }
 
+
+- (NSString *)replaceMonthNameWithStandaloneInText:(NSString *)text withFormat:(NSString *)format {
+    if ([format containsString:@"d"]) {
+        return text; // Format contains day, so replacement to standalone month name does not needed
+    }
+    if ([format containsString:@"MMMM"]) { // full month name replacement
+        for (uint i = 0; i < 12; i++) {
+            NSString *monthName = [self monthSymbols][i];
+            if ([text containsString:monthName]) {
+                NSString *standaloneMonthName = [self standaloneMonthSymbols][i];
+                text = [text stringByReplacingOccurrencesOfString:monthName withString:standaloneMonthName];
+            }
+        }
+    }
+    if ([format containsString:@"MMMMM"]) { // very short month name replacement
+        for (uint i = 0; i < 12; i++) {
+            NSString *monthName = [self veryShortMonthSymbols][i];
+            if ([text containsString:monthName]) {
+                NSString *standaloneMonthName = [self veryShortStandaloneMonthSymbols][i];
+                text = [text stringByReplacingOccurrencesOfString:monthName withString:standaloneMonthName];
+            }
+        }
+    }
+    else if ([format containsString:@"MMMM"]) { // full month name replacement
+        for (uint i = 0; i < 12; i++) {
+            NSString *monthName = [self monthSymbols][i];
+            if ([text containsString:monthName]) {
+                NSString *standaloneMonthName = [self standaloneMonthSymbols][i];
+                text = [text stringByReplacingOccurrencesOfString:monthName withString:standaloneMonthName];
+            }
+        }
+    }
+    else if ([format containsString:@"MMM"]) { // short month name replacement
+        for (uint i = 0; i < 12; i++) {
+            NSString *monthName = [self shortMonthSymbols][i];
+            if ([text containsString:monthName]) {
+                NSString *standaloneMonthName = [self shortStandaloneMonthSymbols][i];
+                text = [text stringByReplacingOccurrencesOfString:monthName withString:standaloneMonthName];
+            }
+        }
+    }
+    return text;
+}
+
 @end
 
 @implementation NSMapTable (FSCalendarExtensions)

--- a/FSCalendar/FSCalendarHeaderView.m
+++ b/FSCalendar/FSCalendarHeaderView.m
@@ -217,6 +217,7 @@
             break;
         }
     }
+	text = [[_calendar gregorian] replaceMonthNameWithStandaloneInText:text withFormat:appearance.headerDateFormat];
     text = usesUpperCase ? text.uppercaseString : text;
     cell.titleLabel.text = text;
     [cell setNeedsLayout];

--- a/FSCalendar/FSCalendarStickyHeader.m
+++ b/FSCalendar/FSCalendarStickyHeader.m
@@ -99,6 +99,7 @@
     _calendar.formatter.dateFormat = self.calendar.appearance.headerDateFormat;
     BOOL usesUpperCase = (self.calendar.appearance.caseOptions & 15) == FSCalendarCaseOptionsHeaderUsesUpperCase;
     NSString *text = [_calendar.formatter stringFromDate:_month];
+	text = [[self.calendar gregorian] replaceMonthNameWithStandaloneInText:text withFormat:self.calendar.appearance.headerDateFormat];
     text = usesUpperCase ? text.uppercaseString : text;
     self.titleLabel.text = text;
 }


### PR DESCRIPTION
When calendar header format has no day, month name must be in normal wordform, i.e. component must use standalone month names (`NSCalendar.standaloneMonthSymbols` property)
But `NSCalendar.monthSymbols` property using, so component was not usable in some languages

This commit fixes [issue 606](https://github.com/WenchaoD/FSCalendar/issues/606)