### PR TITLE
Use defaultTimeZone instead of localTimeZone

### DIFF
--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -158,7 +158,7 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
     _formatter = [[NSDateFormatter alloc] init];
     _formatter.dateFormat = @"yyyy-MM-dd";
     _locale = [NSLocale currentLocale];
-    _timeZone = [NSTimeZone localTimeZone];
+    _timeZone = [NSTimeZone defaultTimeZone];
     _firstWeekday = 1;
     [self invalidateDateTools];
     


### PR DESCRIPTION
We've had some broken functionality in our application.

`localTimeZone` is broken in iOS 11. It does not point to `defaultTimeZone`.

This bug causes FSCalendar's timezone to be `systemTimeZone` instead of `defaultTimeZone`.


This fix will allow FSCalendar's timezone to be `defaultTimeZone`.

https://forums.developer.apple.com/thread/86951

https://stackoverflow.com/questions/46499155/ios-11-nstimezone-localtimezone-ignoring-nstimezone-defaulttimezone

https://openradar.appspot.com/34507729