### PR TITLE
Added public updateBoundingRect function, to remove erroneous blank 6th row

### DIFF
--- a/FSCalendar/FSCalendar.h
+++ b/FSCalendar/FSCalendar.h
@@ -483,6 +483,12 @@ IB_DESIGNABLE
 - (void)setCurrentPage:(NSDate *)currentPage animated:(BOOL)animated;
 
 /**
+Updates the bounding rect of the calendar. 
+Calling this function ensures that there is no blank space at the bottom of the calendar when the selected month only has 5 rows. 
+*/
+- (BOOL)updateBoundingRect;
+
+/**
  Register a class for use in creating new calendar cells.
 
  @param cellClass The class of a cell that you want to use in the calendar.

--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -1670,6 +1670,20 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
     [self.calendarWeekdayView configureAppearance];
 }
 
+- (BOOL)updateBoundingRect {
+    if(self.transitionCoordinator.state == FSCalendarTransitionStateIdle) {
+        self.transitionCoordinator.state = FSCalendarTransitionStateChanging;
+        CGRect bounds = (CGRect){CGPointZero,[self sizeThatFits:self.frame.size scope:FSCalendarScopeMonth]};
+        self.needsAdjustingViewFrame = YES;
+        [self setNeedsLayout];
+        [self.transitionCoordinator boundingRectWillChange:bounds animated:NO];
+        self.transitionCoordinator.state = FSCalendarTransitionStateIdle;
+        return YES;
+    }
+    return NO;
+   
+}
+
 @end
 
 

--- a/FSCalendar/FSCalendarTransitionCoordinator.h
+++ b/FSCalendar/FSCalendarTransitionCoordinator.h
@@ -40,6 +40,8 @@ typedef NS_ENUM(NSUInteger, FSCalendarTransitionState) {
 - (void)performScopeTransitionFromScope:(FSCalendarScope)fromScope toScope:(FSCalendarScope)toScope animated:(BOOL)animated;
 - (void)performBoundingRectTransitionFromMonth:(NSDate *)fromMonth toMonth:(NSDate *)toMonth duration:(CGFloat)duration;
 
+- (void)boundingRectWillChange:(CGRect)targetBounds animated:(BOOL)animated
+
 - (void)handleScopeGesture:(id)sender;
 
 @end


### PR DESCRIPTION
Sometimes, when the number of rows in the month is 5 and .placeholderType is not set to .fillSixRows, there is an erroneous blank space at the end of the FSCalendar. It is only fixed upon switching the selected month from September (a 6-row month) to another month. 

In my app, the blank space appears whenever the calendar's AutoLayout constraints are updated and whenever the app is loaded, even from the background. 

The function I added (to FSCalendar.m) calls the boundingRectWillChange of the FSCalendarTransitionCoordinator with the calendar's current frame, removing the blank space as the performBoundingRectTransitionFromMonth function does.