### PR TITLE
allow the header can be click, so we can use DatePicker  to change the year

### DIFF
--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -1387,8 +1387,6 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
         if (_scrollEnabled) {
             if (!_deliver) {
                 FSCalendarHeaderTouchDeliver *deliver = [[FSCalendarHeaderTouchDeliver alloc] initWithFrame:CGRectZero];
-                deliver.header = _calendarHeaderView;
-                deliver.calendar = self;
                 [_contentView addSubview:deliver];
                 self.deliver = deliver;
             }

--- a/FSCalendar/FSCalendarDynamicHeader.h
+++ b/FSCalendar/FSCalendarDynamicHeader.h
@@ -24,6 +24,7 @@
 
 @interface FSCalendar (Dynamic)
 
+@property (readonly, nonatomic) FSCalendarHeaderTouchDeliver *deliver;
 @property (readonly, nonatomic) FSCalendarCollectionView *collectionView;
 @property (readonly, nonatomic) FSCalendarScopeHandle *scopeHandle;
 @property (readonly, nonatomic) FSCalendarCollectionViewLayout *collectionViewLayout;

--- a/FSCalendar/FSCalendarHeaderView.h
+++ b/FSCalendar/FSCalendarHeaderView.h
@@ -43,7 +43,4 @@
 
 @interface FSCalendarHeaderTouchDeliver : UIView
 
-@property (weak, nonatomic) FSCalendar *calendar;
-@property (weak, nonatomic) FSCalendarHeaderView *header;
-
 @end

--- a/FSCalendar/FSCalendarHeaderView.m
+++ b/FSCalendar/FSCalendarHeaderView.m
@@ -309,15 +309,6 @@
 
 @implementation FSCalendarHeaderTouchDeliver
 
-- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
-{
-    UIView *hitView = [super hitTest:point withEvent:event];
-    if (hitView == self) {
-        return _calendar.collectionView ?: hitView;
-    }
-    return hitView;
-}
-
 @end
 
 


### PR DESCRIPTION
经过修改以后，通过以下代码便可以自定义Header的点击事件：
in viewDidLoad():
`        calendar.deliver.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(LastPagerController.onCalendarHeaderClick(_:)) ))`
in Controller class:
```
    @objc func onCalendarHeaderClick(_ ges : UITapGestureRecognizer) {
       //datePicker可以动画形式出现，需要自定义
        datePicker.isHidden = false
    }
```