### PR TITLE
Add possibility to change sticky header separator color and set custom month headers.

### DIFF
--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -492,6 +492,7 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
             FSCalendarStickyHeader *stickyHeader = [collectionView dequeueReusableSupplementaryViewOfKind:UICollectionElementKindSectionHeader withReuseIdentifier:@"header" forIndexPath:indexPath];
             stickyHeader.calendar = self;
             stickyHeader.month = [self.gregorian dateByAddingUnit:NSCalendarUnitMonth value:indexPath.section toDate:[self.gregorian fs_firstDayOfMonth:_minimumDate] options:0];
+            stickyHeader.separatorLineColor = self.appearance.stickyHeaderSeparatorColor;
             self.visibleSectionHeaders[indexPath] = stickyHeader;
             [stickyHeader setNeedsLayout];
             return stickyHeader;

--- a/FSCalendar/FSCalendarAppearance.h
+++ b/FSCalendar/FSCalendarAppearance.h
@@ -114,6 +114,16 @@ typedef NS_OPTIONS(NSUInteger, FSCalendarCaseOptions) {
 @property (assign, nonatomic) CGFloat  headerMinimumDissolvedAlpha;
 
 /**
+ * Allow header custom title text.
+ */
+@property (assign, nonatomic) BOOL isHeaderCustomTitle;
+
+/**
+ * Array of custom header titles.
+ */
+@property (strong, nonatomic) NSArray *headerTitles;
+
+/**
  * The day text color for unselected state.
  */
 @property (strong, nonatomic) UIColor  *titleDefaultColor;

--- a/FSCalendar/FSCalendarAppearance.h
+++ b/FSCalendar/FSCalendarAppearance.h
@@ -206,6 +206,11 @@ typedef NS_OPTIONS(NSUInteger, FSCalendarCaseOptions) {
  */
 @property (assign, nonatomic) FSCalendarSeparators separators;
 
+/**
+ * The  color of separator for steaky header.
+ */
+@property (strong, nonatomic) UIColor *stickyHeaderSeparatorColor;
+
 #if TARGET_INTERFACE_BUILDER
 
 // For preview only

--- a/FSCalendar/FSCalendarAppearance.m
+++ b/FSCalendar/FSCalendarAppearance.m
@@ -38,6 +38,7 @@
         _headerTitleColor = FSCalendarStandardTitleTextColor;
         _headerDateFormat = @"MMMM yyyy";
         _headerMinimumDissolvedAlpha = 0.2;
+        _isHeaderCustomTitle = NO;
         _weekdayTextColor = FSCalendarStandardTitleTextColor;
         _caseOptions = FSCalendarCaseOptionsHeaderUsesDefaultCase|FSCalendarCaseOptionsWeekdayUsesDefaultCase;
         
@@ -408,6 +409,21 @@
 {
     if (_headerMinimumDissolvedAlpha != headerMinimumDissolvedAlpha) {
         _headerMinimumDissolvedAlpha = headerMinimumDissolvedAlpha;
+        [self.calendar configureAppearance];
+    }
+}
+
+- (void)setIsHeaderCustomTitle:(BOOL)isHeaderCustomTitle
+{
+    if (_isHeaderCustomTitle != isHeaderCustomTitle) {
+        _isHeaderCustomTitle = isHeaderCustomTitle;
+        [self.calendar configureAppearance];
+    }
+}
+
+- (void) setHeaderTitles:(NSArray *)headerTitles {
+    if (![_headerTitles isEqual:headerTitles]) {
+        _headerTitles = headerTitles;
         [self.calendar configureAppearance];
     }
 }

--- a/FSCalendar/FSCalendarAppearance.m
+++ b/FSCalendar/FSCalendarAppearance.m
@@ -71,6 +71,8 @@
         
         _borderColors = [NSMutableDictionary dictionaryWithCapacity:2];
         
+        _stickyHeaderSeparatorColor = FSCalendarStandardLineColor;
+        
 #if TARGET_INTERFACE_BUILDER
         _fakeEventDots = YES;
 #endif
@@ -430,6 +432,14 @@
 {
     if (_separators != separators) {
         _separators = separators;
+        [_calendar.collectionView.collectionViewLayout invalidateLayout];
+    }
+}
+
+- (void)setStickyHeaderSeparatorColor:(UIColor *)stickyHeaderSeparatorColor
+{
+    if (_stickyHeaderSeparatorColor != stickyHeaderSeparatorColor) {
+        _stickyHeaderSeparatorColor = stickyHeaderSeparatorColor;
         [_calendar.collectionView.collectionViewLayout invalidateLayout];
     }
 }

--- a/FSCalendar/FSCalendarHeaderView.m
+++ b/FSCalendar/FSCalendarHeaderView.m
@@ -195,11 +195,23 @@
                     text = nil;
                 } else {
                     NSDate *date = [self.calendar.gregorian dateByAddingUnit:NSCalendarUnitMonth value:indexPath.item-1 toDate:self.calendar.minimumDate options:0];
-                    text = [_calendar.formatter stringFromDate:date];
+                    if (self.calendar.appearance.isHeaderCustomTitle) {
+                        NSDateComponents *components = [[NSCalendar currentCalendar] components: NSCalendarUnitMonth fromDate:date];
+                        NSInteger monthNumber = [components month] - 1;
+                        text = (self.calendar.appearance.headerTitles && [self.calendar.appearance.headerTitles count] > monthNumber) ? self.calendar.appearance.headerTitles[monthNumber] : @"";
+                    } else {
+                        text = [_calendar.formatter stringFromDate:date];
+                    }
                 }
             } else {
                 NSDate *date = [self.calendar.gregorian dateByAddingUnit:NSCalendarUnitMonth value:indexPath.item toDate:self.calendar.minimumDate options:0];
-                text = [_calendar.formatter stringFromDate:date];
+                if (self.calendar.appearance.isHeaderCustomTitle) {
+                    NSDateComponents *components = [[NSCalendar currentCalendar] components: NSCalendarUnitMonth fromDate:date];
+                    NSInteger monthNumber = [components month] - 1;
+                    text = (self.calendar.appearance.headerTitles && [self.calendar.appearance.headerTitles count] > monthNumber) ? self.calendar.appearance.headerTitles[monthNumber] : @"";
+                } else {
+                    text = [_calendar.formatter stringFromDate:date];
+                }
             }
             break;
         }

--- a/FSCalendar/FSCalendarStickyHeader.h
+++ b/FSCalendar/FSCalendarStickyHeader.h
@@ -18,6 +18,8 @@
 
 @property (strong, nonatomic) NSDate *month;
 
+@property (strong, nonatomic) UIColor *separatorLineColor;
+
 - (void)configureAppearance;
 
 @end

--- a/FSCalendar/FSCalendarStickyHeader.m
+++ b/FSCalendar/FSCalendarStickyHeader.m
@@ -84,6 +84,13 @@
     }
 }
 
+- (void) setSeparatorLineColor:(UIColor *)separatorLineColor
+{
+    if(self.bottomBorder) {
+        self.bottomBorder.backgroundColor = separatorLineColor;
+    }
+}
+
 #pragma mark - Private methods
 
 - (void)configureAppearance

--- a/FSCalendar/FSCalendarStickyHeader.m
+++ b/FSCalendar/FSCalendarStickyHeader.m
@@ -103,11 +103,18 @@
 - (void)setMonth:(NSDate *)month
 {
     _month = month;
-    _calendar.formatter.dateFormat = self.calendar.appearance.headerDateFormat;
-    BOOL usesUpperCase = (self.calendar.appearance.caseOptions & 15) == FSCalendarCaseOptionsHeaderUsesUpperCase;
-    NSString *text = [_calendar.formatter stringFromDate:_month];
-    text = usesUpperCase ? text.uppercaseString : text;
-    self.titleLabel.text = text;
+    if(self.calendar.appearance.isHeaderCustomTitle) {
+        NSDateComponents *components = [[NSCalendar currentCalendar] components: NSCalendarUnitMonth fromDate:_month];
+        NSInteger monthNumber = [components month] - 1;
+        NSString *text = (self.calendar.appearance.headerTitles && [self.calendar.appearance.headerTitles count] > monthNumber) ? self.calendar.appearance.headerTitles[monthNumber] : @"";
+        self.titleLabel.text = text;
+    } else {
+        _calendar.formatter.dateFormat = self.calendar.appearance.headerDateFormat;
+        BOOL usesUpperCase = (self.calendar.appearance.caseOptions & 15) == FSCalendarCaseOptionsHeaderUsesUpperCase;
+        NSString *text = [_calendar.formatter stringFromDate:_month];
+        text = usesUpperCase ? text.uppercaseString : text;
+        self.titleLabel.text = text;
+    }
 }
 
 @end


### PR DESCRIPTION
We need this because some languages have grammatical cases for months and default calendar returns wrong month name in the wrong case and word begins from small letter.