### PR TITLE
Enables application extension API only

### DIFF
--- a/Example-Objc/FSCalendar.xcodeproj/project.pbxproj
+++ b/Example-Objc/FSCalendar.xcodeproj/project.pbxproj
@@ -919,6 +919,7 @@
 		EE638CFC1B8A1F550006DD1A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -945,6 +946,7 @@
 		EE638CFD1B8A1F550006DD1A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
Adds support for using FSCalendar in application extension. OHHTPStubs does not use any API which is restricted inside extension, so enabling support is just ticking 1 box.

Linking FSCalendar to an application extension works find but creates a warning. This change targets a warning free project.