### PR TITLE
Add appearance Sunday and Saturday Text Color

### DIFF
--- a/FSCalendar/FSCalendarAppearance.h
+++ b/FSCalendar/FSCalendarAppearance.h
@@ -99,6 +99,16 @@ typedef NS_OPTIONS(NSUInteger, FSCalendarCaseOptions) {
 @property (strong, nonatomic) UIColor  *weekdayTextColor;
 
 /**
+ * The color of sunday text.
+ */
+@property (strong, nonatomic) UIColor  *sundayTextColor;
+
+/**
+ * The color of saturday text.
+ */
+@property (strong, nonatomic) UIColor  *saturdayTextColor;
+
+/**
  * The color of month header text.
  */
 @property (strong, nonatomic) UIColor  *headerTitleColor;

--- a/FSCalendar/FSCalendarWeekdayView.m
+++ b/FSCalendar/FSCalendarWeekdayView.m
@@ -106,7 +106,7 @@
         NSInteger index = (i + self.calendar.firstWeekday-1) % 7;
         UILabel *label = [self.weekdayPointers pointerAtIndex:i];
         label.font = self.calendar.appearance.weekdayFont;
-        label.textColor = self.calendar.appearance.weekdayTextColor;
+        label.textColor = i == 0 ? self.calendar.appearance.sundayTextColor : i == 6 ? self.calendar.appearance.saturdayTextColor : self.calendar.appearance.weekdayTextColor;
         label.text = useDefaultWeekdayCase ? weekdaySymbols[index] : [weekdaySymbols[index] uppercaseString];
     }
 


### PR DESCRIPTION
In the Japanese standard calendar, Sunday is Red, Saturday is Blue.

![9275](https://user-images.githubusercontent.com/5770480/56364438-7f463700-6229-11e9-9b4a-b292b129f807.png)


## Example

```
                self.calendar.appearance.weekdayTextColor = UIColor.black
                self.calendar.appearance.sundayTextColor = UIColor.red
                self.calendar.appearance.saturdayTextColor = UIColor.blue
```

