### PR TITLE
Fixes iOS 13 reverting back to "Times New Roman" when changing the font size of default system fonts

### DIFF
--- a/FSCalendar/FSCalendarAppearance.m
+++ b/FSCalendar/FSCalendarAppearance.m
@@ -482,22 +482,22 @@
 
 - (void)setTitleTextSize:(CGFloat)titleTextSize
 {
-    self.titleFont = [UIFont fontWithName:self.titleFont.fontName size:titleTextSize];
+    self.titleFont = [self.titleFont fontWithSize:titleTextSize];
 }
 
 - (void)setSubtitleTextSize:(CGFloat)subtitleTextSize
 {
-    self.subtitleFont = [UIFont fontWithName:self.subtitleFont.fontName size:subtitleTextSize];
+    self.subtitleFont = [self.subtitleFont fontWithSize:subtitleTextSize];
 }
 
 - (void)setWeekdayTextSize:(CGFloat)weekdayTextSize
 {
-    self.weekdayFont = [UIFont fontWithName:self.weekdayFont.fontName size:weekdayTextSize];
+    self.weekdayFont = [self.weekdayFont fontWithSize:weekdayTextSize];
 }
 
 - (void)setHeaderTitleTextSize:(CGFloat)headerTitleTextSize
 {
-    self.headerTitleFont = [UIFont fontWithName:self.headerTitleFont.fontName size:headerTitleTextSize];
+    self.headerTitleFont = [self.headerTitleFont fontWithSize:headerTitleTextSize];
 }
 
 - (void)invalidateAppearance


### PR DESCRIPTION
Fixes iOS 13 reverting back to "Times New Roman" when changing the font size of default system fonts.

This fix uses the proper method for changing the font size of an existing font. You should not use internal Apple font names, they may change at any moment.