### PR TITLE
september 2019 first row in month-view-mode problem fixed

### DIFF
--- a/FSCalendar/FSCalendarCalculator.m
+++ b/FSCalendar/FSCalendarCalculator.m
@@ -178,7 +178,8 @@
     if (!monthHead) {
         NSDate *month = [self.gregorian dateByAddingUnit:NSCalendarUnitMonth value:section toDate:[self.gregorian fs_firstDayOfMonth:self.minimumDate] options:0];
         NSInteger numberOfHeadPlaceholders = [self numberOfHeadPlaceholdersForMonth:month];
-        monthHead = [self.gregorian dateByAddingUnit:NSCalendarUnitDay value:-numberOfHeadPlaceholders toDate:month options:0];
+        monthHead = [self.gregorian dateByAddingUnit:NSCalendarUnitDay value:
+                     - (numberOfHeadPlaceholders % 7) toDate:month options:0];
         self.months[key] = month;
         self.monthHeads[key] = monthHead;
     }


### PR DESCRIPTION
This commit fixes a problem that is visible in month view mode in September 2019.

Problem: 
After scrolling to September 2019 the first week is from August and the last week of September is not visible:
<img width="350" alt="september_2019_problem" src="https://user-images.githubusercontent.com/2103762/65908955-c5eab080-e3c7-11e9-855e-e29db9e05792.png">

Fixed:
![september_2019_problem_fixed](https://user-images.githubusercontent.com/2103762/65909021-e7e43300-e3c7-11e9-97cb-38cd9a131845.jpeg)

