### PR TITLE
Fixed unrecognized selector sent to instance [FSCalendarBlankCell]

### DIFF
--- a/FSCalendar/FSCalendarCell.m
+++ b/FSCalendar/FSCalendarCell.m
@@ -461,7 +461,7 @@ OFFSET_PROPERTY(preferredEventOffset, PreferredEventOffset, _appearance.eventOff
 @implementation FSCalendarBlankCell
 
 - (void)configureAppearance {}
-
+- (void)performSelecting {}
 @end
 
 


### PR DESCRIPTION
This commit fixes the error:
`[FSCalendarBlankCell performSelecting]: unrecognized selector sent to instance`
The error may be related to the problem described in Pull Request #1117 