### PR TITLE
FixFirstWeekdayBugInFSCalendarScopeWeek

### DIFF
--- a/FSCalendar/FSCalendarDynamicHeader.h
+++ b/FSCalendar/FSCalendarDynamicHeader.h
@@ -31,7 +31,6 @@
 @property (readonly, nonatomic) NSArray *visibleStickyHeaders;
 @property (readonly, nonatomic) CGFloat preferredHeaderHeight;
 @property (readonly, nonatomic) CGFloat preferredWeekdayHeight;
-@property (readonly, nonatomic) UIView *bottomBorder;
 
 @property (readonly, nonatomic) NSCalendar *gregorian;
 @property (readonly, nonatomic) NSDateFormatter *formatter;
@@ -41,12 +40,8 @@
 
 @property (assign, nonatomic) BOOL needsAdjustingViewFrame;
 
-- (void)invalidateHeaders;
 - (void)adjustMonthPosition;
 - (void)configureAppearance;
-
-- (BOOL)isPageInRange:(NSDate *)page;
-- (BOOL)isDateInRange:(NSDate *)date;
 
 - (CGSize)sizeThatFits:(CGSize)size scope:(FSCalendarScope)scope;
 


### PR DESCRIPTION
Fix https://github.com/WenchaoD/FSCalendar/issues/1100 and https://github.com/WenchaoD/FSCalendar/issues/1102
If firstWeekday is not 1, and weekday is less than firstWeekday, the middleDayOfWeek will be the middle day of next week