### PR TITLE
Fix 'Converting a pointer value of type 'NSNumber *' warning

### DIFF
--- a/FSCalendar/FSCalendarCalculator.m
+++ b/FSCalendar/FSCalendarCalculator.m
@@ -221,7 +221,7 @@
     if (self.calendar.placeholderType == FSCalendarPlaceholderTypeFillSixRows) return 6;
     
     NSNumber *rowCount = self.rowCounts[month];
-    if (!rowCount) {
+    if (rowCount == nil) {
         NSDate *firstDayOfMonth = [self.gregorian fs_firstDayOfMonth:month];
         NSInteger weekdayOfFirstDay = [self.gregorian component:NSCalendarUnitWeekday fromDate:firstDayOfMonth];
         NSInteger numberOfDaysInMonth = [self.gregorian fs_numberOfDaysInMonth:month];


### PR DESCRIPTION
This fixes the following Clang analyzer warning 'Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue'