### PR TITLE
Header customization

### DIFF
--- a/FSCalendar/FSCalendarAppearance.h
+++ b/FSCalendar/FSCalendarAppearance.h
@@ -29,7 +29,8 @@ typedef NS_ENUM(NSUInteger, FSCalendarSeparators) {
 
 typedef NS_OPTIONS(NSUInteger, FSCalendarCaseOptions) {
     FSCalendarCaseOptionsHeaderUsesDefaultCase      = 0,
-    FSCalendarCaseOptionsHeaderUsesUpperCase        = 1,
+    FSCalendarCaseOptionsHeaderUsesUpperCase        = 1 << 0,
+    FSCalendarCaseOptionsHeaderUsesCapitalized      = 1 << 1,
     
     FSCalendarCaseOptionsWeekdayUsesDefaultCase     = 0 << 4,
     FSCalendarCaseOptionsWeekdayUsesUpperCase       = 1 << 4,

--- a/FSCalendar/FSCalendarAppearance.h
+++ b/FSCalendar/FSCalendarAppearance.h
@@ -114,6 +114,11 @@ typedef NS_OPTIONS(NSUInteger, FSCalendarCaseOptions) {
 @property (strong, nonatomic) NSString *headerDateFormat;
 
 /**
+ * The text alignment of the month header.
+ */
+@property (assign, nonatomic) NSTextAlignment headerTitleAlignment;
+
+/**
  * The alpha value of month label staying on the fringes.
  */
 @property (assign, nonatomic) CGFloat  headerMinimumDissolvedAlpha;

--- a/FSCalendar/FSCalendarAppearance.h
+++ b/FSCalendar/FSCalendarAppearance.h
@@ -64,6 +64,11 @@ typedef NS_OPTIONS(NSUInteger, FSCalendarCaseOptions) {
 @property (strong, nonatomic) UIFont   *headerTitleFont;
 
 /**
+ * The offset of the month header from default position.
+ */
+@property (assign, nonatomic) CGPoint  headerTitleOffset;
+
+/**
  * The offset of the day text from default position.
  */
 @property (assign, nonatomic) CGPoint  titleOffset;

--- a/FSCalendar/FSCalendarAppearance.h
+++ b/FSCalendar/FSCalendarAppearance.h
@@ -109,6 +109,11 @@ typedef NS_OPTIONS(NSUInteger, FSCalendarCaseOptions) {
 @property (strong, nonatomic) UIColor  *headerTitleColor;
 
 /**
+ * The color oh month header separator
+ */
+@property (strong, nonatomic) UIColor  *headerSeparatorColor;
+
+/**
  * The date format of the month header.
  */
 @property (strong, nonatomic) NSString *headerDateFormat;

--- a/FSCalendar/FSCalendarAppearance.m
+++ b/FSCalendar/FSCalendarAppearance.m
@@ -111,6 +111,13 @@
     }
 }
 
+- (void)setHeaderTitleOffset:(CGPoint)headerTitleOffset {
+    if (!CGPointEqualToPoint(_headerTitleOffset, headerTitleOffset)) {
+        _headerTitleOffset = headerTitleOffset;
+        [self.calendar configureAppearance];
+    }
+}
+
 - (void)setTitleOffset:(CGPoint)titleOffset
 {
     if (!CGPointEqualToPoint(_titleOffset, titleOffset)) {

--- a/FSCalendar/FSCalendarAppearance.m
+++ b/FSCalendar/FSCalendarAppearance.m
@@ -425,6 +425,14 @@
     }
 }
 
+- (void)setHeaderTitleAlignment:(NSTextAlignment)headerTitleAlignment
+{
+    if (_headerTitleAlignment != headerTitleAlignment) {
+        _headerTitleAlignment = headerTitleAlignment;
+        [self.calendar configureAppearance];
+    }
+}
+
 - (void)setCaseOptions:(FSCalendarCaseOptions)caseOptions
 {
     if (_caseOptions != caseOptions) {

--- a/FSCalendar/FSCalendarAppearance.m
+++ b/FSCalendar/FSCalendarAppearance.m
@@ -36,6 +36,7 @@
         _headerTitleFont = [UIFont systemFontOfSize:FSCalendarStandardHeaderTextSize];
         
         _headerTitleColor = FSCalendarStandardTitleTextColor;
+        _headerSeparatorColor = FSCalendarStandardLineColor;
         _headerDateFormat = @"MMMM yyyy";
         _headerMinimumDissolvedAlpha = 0.2;
         _weekdayTextColor = FSCalendarStandardTitleTextColor;
@@ -405,6 +406,14 @@
 {
     if (![_headerTitleColor isEqual:color]) {
         _headerTitleColor = color;
+        [self.calendar configureAppearance];
+    }
+}
+
+- (void)setHeaderSeparatorColor:(UIColor *)headerSeparatorColor
+{
+    if (![_headerSeparatorColor isEqual:headerSeparatorColor]) {
+        _headerSeparatorColor = headerSeparatorColor;
         [self.calendar configureAppearance];
     }
 }

--- a/FSCalendar/FSCalendarHeaderView.m
+++ b/FSCalendar/FSCalendarHeaderView.m
@@ -229,8 +229,11 @@
 - (void)layoutSubviews
 {
     [super layoutSubviews];
-    
-    self.titleLabel.frame = self.contentView.bounds;
+
+    CGPoint titleHeaderOffset = self.header.calendar.appearance.headerTitleOffset;
+    self.titleLabel.frame = CGRectOffset(self.contentView.bounds,
+                                         titleHeaderOffset.x,
+                                         titleHeaderOffset.y);
     
     if (self.header.scrollDirection == UICollectionViewScrollDirectionHorizontal) {
         CGFloat position = [self.contentView convertPoint:CGPointMake(CGRectGetMidX(self.contentView.bounds), CGRectGetMidY(self.contentView.bounds)) toView:self.header].x;

--- a/FSCalendar/FSCalendarHeaderView.m
+++ b/FSCalendar/FSCalendarHeaderView.m
@@ -158,7 +158,6 @@
     cell.titleLabel.textColor = appearance.headerTitleColor;
     cell.titleLabel.textAlignment = appearance.headerTitleAlignment; 
     _calendar.formatter.dateFormat = appearance.headerDateFormat;
-    BOOL usesUpperCase = (appearance.caseOptions & 15) == FSCalendarCaseOptionsHeaderUsesUpperCase;
     NSString *text = nil;
     switch (self.calendar.transitionCoordinator.representingScope) {
         case FSCalendarScopeMonth: {
@@ -190,7 +189,13 @@
             break;
         }
     }
-    text = usesUpperCase ? text.uppercaseString : text;
+    BOOL usesUpperCase   = (appearance.caseOptions & 15) == FSCalendarCaseOptionsHeaderUsesUpperCase;
+    BOOL usesCapitalized = (appearance.caseOptions & 15) == FSCalendarCaseOptionsHeaderUsesCapitalized;
+    if (usesUpperCase) {
+        text = text.uppercaseString;
+    } else if (usesCapitalized) {
+        text = text.capitalizedString;
+    }
     cell.titleLabel.text = text;
     [cell setNeedsLayout];
 }

--- a/FSCalendar/FSCalendarHeaderView.m
+++ b/FSCalendar/FSCalendarHeaderView.m
@@ -156,6 +156,7 @@
     FSCalendarAppearance *appearance = self.calendar.appearance;
     cell.titleLabel.font = appearance.headerTitleFont;
     cell.titleLabel.textColor = appearance.headerTitleColor;
+    cell.titleLabel.textAlignment = appearance.headerTitleAlignment; 
     _calendar.formatter.dateFormat = appearance.headerDateFormat;
     BOOL usesUpperCase = (appearance.caseOptions & 15) == FSCalendarCaseOptionsHeaderUsesUpperCase;
     NSString *text = nil;

--- a/FSCalendar/FSCalendarStickyHeader.m
+++ b/FSCalendar/FSCalendarStickyHeader.m
@@ -103,9 +103,16 @@
 {
     _month = month;
     _calendar.formatter.dateFormat = self.calendar.appearance.headerDateFormat;
-    BOOL usesUpperCase = (self.calendar.appearance.caseOptions & 15) == FSCalendarCaseOptionsHeaderUsesUpperCase;
+    BOOL usesUpperCase   = (self.calendar.appearance.caseOptions & 15) == FSCalendarCaseOptionsHeaderUsesUpperCase;
+    BOOL usesCapitalized = (self.calendar.appearance.caseOptions & 15) == FSCalendarCaseOptionsHeaderUsesCapitalized;
+
     NSString *text = [_calendar.formatter stringFromDate:_month];
-    text = usesUpperCase ? text.uppercaseString : text;
+    if (usesUpperCase) {
+        text = text.uppercaseString;
+    } else if (usesCapitalized) {
+        text = text.capitalizedString;
+    }
+
     self.titleLabel.text = text;
 }
 

--- a/FSCalendar/FSCalendarStickyHeader.m
+++ b/FSCalendar/FSCalendarStickyHeader.m
@@ -95,6 +95,7 @@
     _titleLabel.font = self.calendar.appearance.headerTitleFont;
     _titleLabel.textColor = self.calendar.appearance.headerTitleColor;
     _titleLabel.textAlignment = self.calendar.appearance.headerTitleAlignment;
+    _bottomBorder.backgroundColor = self.calendar.appearance.headerSeparatorColor;
     [self.weekdayView configureAppearance];
 }
 

--- a/FSCalendar/FSCalendarStickyHeader.m
+++ b/FSCalendar/FSCalendarStickyHeader.m
@@ -94,6 +94,7 @@
 {
     _titleLabel.font = self.calendar.appearance.headerTitleFont;
     _titleLabel.textColor = self.calendar.appearance.headerTitleColor;
+    _titleLabel.textAlignment = self.calendar.appearance.headerTitleAlignment;
     [self.weekdayView configureAppearance];
 }
 

--- a/FSCalendar/FSCalendarStickyHeader.m
+++ b/FSCalendar/FSCalendarStickyHeader.m
@@ -69,8 +69,12 @@
     CGFloat titleHeight = [@"1" sizeWithAttributes:@{NSFontAttributeName:self.calendar.appearance.headerTitleFont}].height*1.5 + weekdayMargin*3;
     
     _bottomBorder.frame = CGRectMake(0, _contentView.fs_height-weekdayHeight-weekdayMargin*2, _contentView.fs_width, 1.0);
-    _titleLabel.frame = CGRectMake(0, _bottomBorder.fs_bottom-titleHeight-weekdayMargin, titleWidth,titleHeight);
-    
+
+    CGPoint titleHeaderOffset = self.calendar.appearance.headerTitleOffset;
+    _titleLabel.frame = CGRectMake(titleHeaderOffset.x,
+                                   titleHeaderOffset.y+_bottomBorder.fs_bottom-titleHeight-weekdayMargin,
+                                   titleWidth,
+                                   titleHeight);
 }
 
 #pragma mark - Properties


### PR DESCRIPTION
Add several customization properties on header : 
- `headerSeparatorColor`
- `headerTitleAlignment`
- `headerTitleOffset`
- `FSCalendarCaseOptionsHeaderUsesCapitalized`

This will fix #1045.