### PR TITLE
check Divisor is 0

### DIFF
--- a/FSCalendar/FSCalendarTransitionCoordinator.m
+++ b/FSCalendar/FSCalendarTransitionCoordinator.m
@@ -136,7 +136,7 @@
         CGFloat maxTranslation = ABS(CGRectGetHeight(self.transitionAttributes.targetBounds) - CGRectGetHeight(self.transitionAttributes.sourceBounds));
         translation = MIN(maxTranslation, translation);
         translation = MAX(0, translation);
-        CGFloat progress = translation/maxTranslation;
+        CGFloat progress = maxTranslation==0? 0 : translation/maxTranslation;
         progress;
     });
     [self performAlphaAnimationWithProgress:progress];


### PR DESCRIPTION
实际使用中滑动过快时，偶尔出现除数为0的导致崩溃的情况