### PR TITLE
Fix to issue with dark mode #1130

### DIFF
--- a/FSCalendar/FSCalendarAppearance.m
+++ b/FSCalendar/FSCalendarAppearance.m
@@ -49,8 +49,11 @@
         _backgroundColors[@(FSCalendarCellStateToday)]       = FSCalendarStandardTodayColor;
         
         _titleColors = [NSMutableDictionary dictionaryWithCapacity:5];
-        _titleColors[@(FSCalendarCellStateNormal)]      = [UIColor blackColor];
-        _titleColors[@(FSCalendarCellStateSelected)]    = [UIColor whiteColor];
+        if (@available(iOS 13.0, *)) {
+            _titleColors[@(FSCalendarCellStateNormal)]      = [UIColor labelColor];
+        } else {
+            _titleColors[@(FSCalendarCellStateNormal)]      = [UIColor blackColor];
+        }        _titleColors[@(FSCalendarCellStateSelected)]    = [UIColor whiteColor];
         _titleColors[@(FSCalendarCellStateDisabled)]    = [UIColor grayColor];
         _titleColors[@(FSCalendarCellStatePlaceholder)] = [UIColor lightGrayColor];
         _titleColors[@(FSCalendarCellStateToday)]       = [UIColor whiteColor];

--- a/FSCalendar/FSCalendarAppearance.m
+++ b/FSCalendar/FSCalendarAppearance.m
@@ -53,7 +53,8 @@
             _titleColors[@(FSCalendarCellStateNormal)]      = [UIColor labelColor];
         } else {
             _titleColors[@(FSCalendarCellStateNormal)]      = [UIColor blackColor];
-        }        _titleColors[@(FSCalendarCellStateSelected)]    = [UIColor whiteColor];
+        }        
+        _titleColors[@(FSCalendarCellStateSelected)]    = [UIColor whiteColor];
         _titleColors[@(FSCalendarCellStateDisabled)]    = [UIColor grayColor];
         _titleColors[@(FSCalendarCellStatePlaceholder)] = [UIColor lightGrayColor];
         _titleColors[@(FSCalendarCellStateToday)]       = [UIColor whiteColor];


### PR DESCRIPTION
Fix to issue with dark mode #1130 
If device running iOS 13 or greater titlecolor for FSCalendarCellStateNormal is changed to UIColor LabelColor instead of black
