### PR TITLE
fix: dateBySettingHour return nil when date is very big or very small

### DIFF
--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -157,7 +157,7 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
     _firstWeekday = 1;
     [self invalidateDateTools];
     
-    _today = [self.gregorian dateBySettingHour:0 minute:0 second:0 ofDate:[NSDate date] options:0];
+    _today = [self.gregorian startOfDayForDate:[NSDate date]];
     _currentPage = [self.gregorian fs_firstDayOfMonth:_today];
     
     
@@ -701,7 +701,7 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
         _today = nil;
     } else {
         FSCalendarAssertDateInBounds(today,self.gregorian,self.minimumDate,self.maximumDate);
-        _today = [self.gregorian dateBySettingHour:0 minute:0 second:0 ofDate:today options:0];
+        _today = [self.gregorian startOfDayForDate:today];
     }
     if (self.hasValidateVisibleLayout) {
         [self.visibleCells makeObjectsPerformSelector:@selector(setDateIsToday:) withObject:nil];
@@ -719,7 +719,7 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
 {
     [self requestBoundingDatesIfNecessary];
     if (self.floatingMode || [self isDateInDifferentPage:currentPage]) {
-        currentPage = [self.gregorian dateBySettingHour:0 minute:0 second:0 ofDate:currentPage options:0];
+        currentPage = [self.gregorian startOfDayForDate:currentPage];
         if ([self isPageInRange:currentPage]) {
             [self scrollToPageForDate:currentPage animated:animated];
         }
@@ -1037,7 +1037,7 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
 
 - (void)deselectDate:(NSDate *)date
 {
-    date = [self.gregorian dateBySettingHour:0 minute:0 second:0 ofDate:date options:0];
+    date = [self.gregorian startOfDayForDate:date];
     if (![_selectedDates containsObject:date]) {
         return;
     }
@@ -1060,7 +1060,7 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
     
     FSCalendarAssertDateInBounds(date,self.gregorian,self.minimumDate,self.maximumDate);
     
-    NSDate *targetDate = [self.gregorian dateBySettingHour:0 minute:0 second:0 ofDate:date options:0];
+    NSDate *targetDate = [self.gregorian startOfDayForDate:date];
     NSIndexPath *targetIndexPath = [self.calculator indexPathForDate:targetDate];
     
     BOOL shouldSelect = YES;
@@ -1534,9 +1534,9 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
         _needsRequestingBoundingDates = NO;
         self.formatter.dateFormat = @"yyyy-MM-dd";
         NSDate *newMin = [self.dataSourceProxy minimumDateForCalendar:self]?:[self.formatter dateFromString:@"1970-01-01"];
-        newMin = [self.gregorian dateBySettingHour:0 minute:0 second:0 ofDate:newMin options:0];
+        newMin = [self.gregorian startOfDayForDate:newMin];
         NSDate *newMax = [self.dataSourceProxy maximumDateForCalendar:self]?:[self.formatter dateFromString:@"2099-12-31"];
-        newMax = [self.gregorian dateBySettingHour:0 minute:0 second:0 ofDate:newMax options:0];
+        newMax = [self.gregorian startOfDayForDate:newMax];
         
         NSAssert([self.gregorian compareDate:newMin toDate:newMax toUnitGranularity:NSCalendarUnitDay] != NSOrderedDescending, @"The minimum date of calendar should be earlier than the maximum.");
         

--- a/FSCalendar/FSCalendarExtensions.m
+++ b/FSCalendar/FSCalendarExtensions.m
@@ -171,7 +171,7 @@
     components.day = - (weekdayComponents.weekday - self.firstWeekday);
     components.day = (components.day-7) % 7;
     NSDate *firstDayOfWeek = [self dateByAddingComponents:components toDate:week options:0];
-    firstDayOfWeek = [self dateBySettingHour:0 minute:0 second:0 ofDate:firstDayOfWeek options:0];
+    firstDayOfWeek = [self startOfDayForDate:firstDayOfWeek];
     components.day = NSIntegerMax;
     return firstDayOfWeek;
 }
@@ -184,7 +184,7 @@
     components.day = - (weekdayComponents.weekday - self.firstWeekday);
     components.day = (components.day-7) % 7 + 6;
     NSDate *lastDayOfWeek = [self dateByAddingComponents:components toDate:week options:0];
-    lastDayOfWeek = [self dateBySettingHour:0 minute:0 second:0 ofDate:lastDayOfWeek options:0];
+    lastDayOfWeek = [self startOfDayForDate:lastDayOfWeek];
     components.day = NSIntegerMax;
     return lastDayOfWeek;
 }


### PR DESCRIPTION
- replace `dateBySettingHour:minute:second:ofDate:options:` to `startOfDayForDate`

当日期设置为一个比较小或者非常大的值时，使用 `dateBySettingHour:minute:second:ofDate:options:` 会返回 nil 或者返回一个错误的值，`startOfDayForDate` 可以避免这种情况发生。

例如：
```
    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
    formatter.dateFormat = @"yyyy-MM-dd";
    
    NSCalendar * gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
    
    NSDate *date = [formatter dateFromString:@"1900-12-31"];
    
    // right
    NSLog(@"%@", [gregorian startOfDayForDate:date]); // Mon Dec 31 00:00:00 1900
    // wrong
    NSLog(@"%@", [gregorian dateBySettingHour:0 minute:0 second:0 ofDate:date options:0]); // Tue Jan  1 00:00:00 1901
```

```
    NSDate *date = [formatter dateFromString:@"1900-01-01"];
    
    // right
    NSLog(@"%@", [gregorian startOfDayForDate:date]); // Mon Jan  1 00:00:00 1900
    // wrong
    NSLog(@"%@", [gregorian dateBySettingHour:0 minute:0 second:0 ofDate:date options:0]); // (null)
```