### PR TITLE
Add Swift 5.3 manifest file

### DIFF
--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -1,0 +1,20 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "FSCalendar",
+    platforms: [.iOS(.v9)],
+    products: [
+        .library(
+            name: "FSCalendar",
+            targets: ["FSCalendar"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "FSCalendar",
+            dependencies: [],
+            path: "FSCalendar/"
+        )
+    ]
+)


### PR DESCRIPTION
If used in Xcode 12, compiling the `FSCalendar` package will output the following warning: 
`The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.2.99.`

By adding this second manifest file (and moving the iOS support to `9.0` and later) the warning goes away. Previous versions of Xcode will keep using the `Package.swift` file and support iOS `8.0`.

For more details please refer to [this](https://josephduffy.co.uk/posts/supporting-multiple-swift-package-versions-without-breaking-compatibility) article