### PR TITLE
Updated minimum ios deployment target to iOS 9 to support XCode12.x without warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "FSCalendar",
-    platforms: [.iOS(.v8)],
+    platforms: [.iOS(.v9)],
     products: [
         .library(
             name: "FSCalendar",


### PR DESCRIPTION
Fix for issue https://github.com/WenchaoD/FSCalendar/issues/1271