### PR TITLE
Fixed month and date views layout after changing size via split view

### DIFF
--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -1506,8 +1506,12 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
     _preferredWeekdayHeight = FSCalendarAutomaticDimension;
     _preferredRowHeight     = FSCalendarAutomaticDimension;
     
-    [self setNeedsLayout];
+    [self.collectionViewLayout invalidateLayout];
     
+    [self setNeedsLayout];
+    [self layoutIfNeeded];
+    
+    [self adjustMonthPosition];
 }
 
 // The best way to detect orientation

--- a/FSCalendar/FSCalendarHeaderView.m
+++ b/FSCalendar/FSCalendarHeaderView.m
@@ -290,6 +290,11 @@
     
 }
 
+- (BOOL)shouldInvalidateLayoutForBoundsChange:(CGRect)newBounds
+{
+    return self.collectionView ? !CGRectEqualToRect(self.collectionView.bounds, newBounds) : false;
+}
+
 - (void)didReceiveOrientationChangeNotification:(NSNotification *)notificatino
 {
     [self invalidateLayout];


### PR DESCRIPTION
If resize app using Split View feature on iPad, content inside `collectionView` and `calendarHeaderView` displayed incorrectly.

![FSCalendarSplitViewFix](https://user-images.githubusercontent.com/80679760/114054154-45e4b700-9898-11eb-8d60-7bb8aba8e34c.png)
