### PR TITLE
Make collectionView public in FSCalendar

### DIFF
--- a/FSCalendar/FSCalendar.h
+++ b/FSCalendar/FSCalendar.h
@@ -16,6 +16,7 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "FSCalendarCollectionView.h"
 #import "FSCalendarAppearance.h"
 #import "FSCalendarConstants.h"
 #import "FSCalendarCell.h"
@@ -241,6 +242,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 IB_DESIGNABLE
 @interface FSCalendar : UIView
+
+@property (weak  , nonatomic) FSCalendarCollectionView   *collectionView;
 
 /**
  * The object that acts as the delegate of the calendar.

--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -54,7 +54,6 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
 
 @property (weak  , nonatomic) UIView                     *contentView;
 @property (weak  , nonatomic) UIView                     *daysContainer;
-@property (weak  , nonatomic) FSCalendarCollectionView   *collectionView;
 @property (weak  , nonatomic) FSCalendarCollectionViewLayout *collectionViewLayout;
 
 @property (strong, nonatomic) FSCalendarTransitionCoordinator *transitionCoordinator;


### PR DESCRIPTION
As different teams might encounter this already but accessing collectionView methods is not possible due to Xcode 12.5 update. This PR should address that.