### PR TITLE
Fix automatic header calculation

### DIFF
--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -886,7 +886,7 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
 - (CGFloat)preferredHeaderHeight
 {
     if (_headerHeight == FSCalendarAutomaticDimension) {
-        if (_preferredWeekdayHeight == FSCalendarAutomaticDimension) {
+        if (_preferredHeaderHeight == FSCalendarAutomaticDimension) {
             if (!self.floatingMode) {
                 CGFloat DIYider = FSCalendarStandardMonthlyPageHeight;
                 CGFloat contentHeight = self.transitionCoordinator.cachedMonthSize.height;


### PR DESCRIPTION
After update my project to iOS 15 I found strange problem.
I have a view controller with FSCalendar which fill it and open this view controller with a pageSheet modal presentation. When I open it above an other controller with fullScreen modal presentation ((it not reproduced with a pageSheet modal presentation)), I see a header which intersects other elements. I debugged header size, it was -1. I found strange condition in `preferredHeaderHeight()`. 
I think need to use  `_preferredHeaderHeight` instead of `_preferredWeekdayHeight`. `_preferredWeekdayHeight` already used and set into `preferredWeekdayHeight()`