### PR TITLE
Prevent from scrolling "overflow".

### DIFF
--- a/FSCalendar/FSCalendarTransitionCoordinator.m
+++ b/FSCalendar/FSCalendarTransitionCoordinator.m
@@ -131,7 +131,37 @@
 {
     if (self.state != FSCalendarTransitionStateChanging) return;
     
-    CGFloat translation = ABS([panGesture translationInView:panGesture.view].y);
+    CGFloat y = [panGesture translationInView:panGesture.view].y;
+    
+    //
+    // Prevent from scrolling "overflow". This happens when we perform
+    //
+    // (1) Scroll down to switch from week view to month view.
+    // (2) Without releasing gesture, reverse scroll direction to up, to switch back week view.
+    // (3) Once we hit week view, and continue the scroll-up action, we can observe scrolling "overflow" behavior.
+    //
+    // or
+    //
+    // (1) Scroll up to switch from month view to week view.
+    // (2) Without releasing gesture, reverse scroll direction to down, to switch back month view.
+    // (3) Once we hit month view, and continue the scroll-down action, we can observe scrolling "overflow" behavior.
+    //
+    switch (self.calendar.scope) {
+        case FSCalendarScopeMonth: {
+            if (y > 0) {
+                y = 0;
+            }
+            break;
+        }
+        case FSCalendarScopeWeek: {
+            if (y < 0) {
+                y = 0;
+            }
+            break;
+        }
+    }
+    
+    CGFloat translation = ABS(y);
     CGFloat progress = ({
         CGFloat maxTranslation = ABS(CGRectGetHeight(self.transitionAttributes.targetBounds) - CGRectGetHeight(self.transitionAttributes.sourceBounds));
         translation = MIN(maxTranslation, translation);


### PR DESCRIPTION
Prevent from scrolling "overflow". This happens when we perform

(1) Scroll down to switch from week view to month view.
(2) Without releasing gesture, reverse scroll direction to up, to switch back week view.
(3) Once we hit week view, and continue the scroll-up action, we can observe scrolling "overflow" behavior.

or

(1) Scroll up to switch from month view to week view.
(2) Without releasing gesture, reverse scroll direction to down, to switch back month view.
(3) Once we hit month view, and continue the scroll-down action, we can observe scrolling "overflow" behavior.

Before the fix, here's the demo of unwanted behavior.

### Before fix

(From week view to month view, then to week view again)

![a](https://user-images.githubusercontent.com/308276/138037010-12259a7f-3410-42ca-a3a2-e28d8a37b16a.gif)

(From month view to week view, then to month view again)

![b](https://user-images.githubusercontent.com/308276/138037228-2d552601-e8d7-4db4-ba96-245d9ee606d3.gif)

### After the fix

(From week view to month view, then to week view again)

![3](https://user-images.githubusercontent.com/308276/138037545-9aec226c-3718-4986-9d55-dabf9d2908a7.gif)

(From month view to week view, then to month view again)

![4](https://user-images.githubusercontent.com/308276/138037719-1d0e74ce-6de3-499d-bb29-2ddc53bfad7c.gif)



