### PR TITLE
Exclude Info.plist from package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ DerivedData
 *.hmap
 *.ipa
 *.idea
+.swiftpm/
 
 # Bundler
 .bundle

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,8 @@ let package = Package(
         .target(
             name: "FSCalendar",
             dependencies: [],
-            path: "FSCalendar/"
+            path: "FSCalendar/",
+            exclude: ["Info.plist"]
         )
     ]
 )


### PR DESCRIPTION
The current main branch triggers a "`found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target`" warning when working with SPM:
<img width="469" alt="Screen Shot 2021-11-08 at 10 45 24" src="https://user-images.githubusercontent.com/5277837/140682898-abcb004f-8bc9-44f3-baaf-8247a133f28f.png">

This PR takes care of that, and also adds the <kbd>.swiftpm</kbd> folder into <kbd>.gitignore</kbd>.
