### PR TITLE
Added feature to set the font of the selected day in calendar

### DIFF
--- a/FSCalendar/FSCalendarAppearance.h
+++ b/FSCalendar/FSCalendarAppearance.h
@@ -50,6 +50,11 @@ typedef NS_OPTIONS(NSUInteger, FSCalendarCaseOptions) {
 @property (strong, nonatomic) UIFont   *titleFont;
 
 /**
+ * The font of the selected day text.
+ */
+@property (strong, nonatomic) UIFont   *titleSelectedFont;
+
+/**
  * The font of the subtitle text.
  */
 @property (strong, nonatomic) UIFont   *subtitleFont;

--- a/FSCalendar/FSCalendarAppearance.m
+++ b/FSCalendar/FSCalendarAppearance.m
@@ -31,6 +31,7 @@
     if (self) {
         
         _titleFont = [UIFont systemFontOfSize:FSCalendarStandardTitleTextSize];
+        _titleSelectedFont = [UIFont systemFontOfSize:FSCalendarStandardSelectedTitleTextSize];
         _subtitleFont = [UIFont systemFontOfSize:FSCalendarStandardSubtitleTextSize];
         _weekdayFont = [UIFont systemFontOfSize:FSCalendarStandardWeekdayTextSize];
         _headerTitleFont = [UIFont systemFontOfSize:FSCalendarStandardHeaderTextSize];
@@ -86,6 +87,14 @@
 {
     if (![_titleFont isEqual:titleFont]) {
         _titleFont = titleFont;
+        [self.calendar configureAppearance];
+    }
+}
+
+- (void)setTitleSelectionFont:(UIFont *)titleSelectedFont
+{
+    if (![_titleSelectedFont isEqual:titleSelectedFont]) {
+        _titleSelectedFont = titleSelectedFont;
         [self.calendar configureAppearance];
     }
 }

--- a/FSCalendar/FSCalendarCell.m
+++ b/FSCalendar/FSCalendarCell.m
@@ -255,10 +255,19 @@
 - (UIColor *)colorForCurrentStateInDictionary:(NSDictionary *)dictionary
 {
     if (self.isSelected) {
+        UIFont *titleSelectedFont = self.calendar.appearance.titleSelectedFont;
+        if (![titleSelectedFont isEqual:_titleLabel.font]) {
+            _titleLabel.font = titleSelectedFont;
+        }
         if (self.dateIsToday) {
             return dictionary[@(FSCalendarCellStateSelected|FSCalendarCellStateToday)] ?: dictionary[@(FSCalendarCellStateSelected)];
         }
         return dictionary[@(FSCalendarCellStateSelected)];
+    } else {
+        UIFont *titleFont = self.calendar.appearance.titleFont;
+        if (![titleFont isEqual:_titleLabel.font]) {
+            _titleLabel.font = titleFont;
+        }
     }
     if (self.dateIsToday && [[dictionary allKeys] containsObject:@(FSCalendarCellStateToday)]) {
         return dictionary[@(FSCalendarCellStateToday)];

--- a/FSCalendar/FSCalendarConstants.h
+++ b/FSCalendar/FSCalendarConstants.h
@@ -23,6 +23,7 @@ CG_EXTERN CGFloat const FSCalendarAutomaticDimension;
 CG_EXTERN CGFloat const FSCalendarDefaultBounceAnimationDuration;
 CG_EXTERN CGFloat const FSCalendarStandardRowHeight;
 CG_EXTERN CGFloat const FSCalendarStandardTitleTextSize;
+CG_EXTERN CGFloat const FSCalendarStandardSelectedTitleTextSize;
 CG_EXTERN CGFloat const FSCalendarStandardSubtitleTextSize;
 CG_EXTERN CGFloat const FSCalendarStandardWeekdayTextSize;
 CG_EXTERN CGFloat const FSCalendarStandardHeaderTextSize;

--- a/FSCalendar/FSCalendarConstants.m
+++ b/FSCalendar/FSCalendarConstants.m
@@ -20,6 +20,7 @@ CGFloat const FSCalendarAutomaticDimension = -1;
 CGFloat const FSCalendarDefaultBounceAnimationDuration = 0.15;
 CGFloat const FSCalendarStandardRowHeight = 38;
 CGFloat const FSCalendarStandardTitleTextSize = 13.5;
+CGFloat const FSCalendarStandardSelectedTitleTextSize = 13.5;
 CGFloat const FSCalendarStandardSubtitleTextSize = 10;
 CGFloat const FSCalendarStandardWeekdayTextSize = 14;
 CGFloat const FSCalendarStandardHeaderTextSize = 16.5;


### PR DESCRIPTION
안녕하세요. 여전히 좋은 라이브러리를 유지보수 해주셔서 감사합니다.
나는 FSCalender 라이브러리를 사용하던 도중에 프로젝트에서 내가 사용하는 기능이 없어서 직접 만들어 보았다.
이것보다 더 좋은 코드가 있다면 그것으로 기능 추가하는게 좋아보인다.

Hello :)
Thank you for maintaining the good library FSCalendar.
when I use FSCalendar, I can't find a feature I want in this library. 
so I made this feature for my project and FSCalendar !

If there is better code than this code, it would be nice to add functionality to it.