### PR TITLE
Update deployment target to 9.0

### DIFF
--- a/FSCalendar.podspec
+++ b/FSCalendar.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/WenchaoD/FSCalendar.git", :tag => s.version.to_s }
 
   s.platform     = :ios
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
   s.requires_arc = true
   s.framework    = 'UIKit', 'QuartzCore'
   s.source_files = 'FSCalendar/*.{h,m}'


### PR DESCRIPTION
Xcode 14.3 has stopped allowing builds with 8.0 as the deployment target; there are some workarounds if you are building an app but if you are building a library that uses this pod you will not be able to lib lint

https://github.com/CocoaPods/CocoaPods/issues/11839
