### PR TITLE
FIX: Colors Array Out Of Bounds

### DIFF
--- a/FSCalendar/FSCalendarCell.m
+++ b/FSCalendar/FSCalendarCell.m
@@ -438,9 +438,11 @@ OFFSET_PROPERTY(preferredEventOffset, PreferredEventOffset, _appearance.eventOff
             }
         } else if ([_color isKindOfClass:[NSArray class]]) {
             NSArray<UIColor *> *colors = (NSArray *)_color;
-            for (int i = 0; i < self.eventLayers.count; i++) {
-                CALayer *eventLayer = [self.eventLayers pointerAtIndex:i];
-                eventLayer.backgroundColor = colors[MIN(i,colors.count-1)].CGColor;
+            if ([colors count] > 0) {
+                for (int i = 0; i < self.eventLayers.count; i++) {
+                    CALayer *eventLayer = [self.eventLayers pointerAtIndex:i];
+                    eventLayer.backgroundColor = colors[MIN(i,colors.count-1)].CGColor;
+                }
             }
         }
         

--- a/FSCalendar/FSCalendarCell.m
+++ b/FSCalendar/FSCalendarCell.m
@@ -438,7 +438,7 @@ OFFSET_PROPERTY(preferredEventOffset, PreferredEventOffset, _appearance.eventOff
             }
         } else if ([_color isKindOfClass:[NSArray class]]) {
             NSArray<UIColor *> *colors = (NSArray *)_color;
-            if ([colors count] > 0) {
+            if ([colors count] > 0 && [self.eventLayers count] > 0) {
                 for (int i = 0; i < self.eventLayers.count; i++) {
                     CALayer *eventLayer = [self.eventLayers pointerAtIndex:i];
                     eventLayer.backgroundColor = colors[MIN(i,colors.count-1)].CGColor;


### PR DESCRIPTION
I've got a crash on `FSCalendarCell.m` line 443 because of the colors array index was out of range, and it's an attempt to fix that.