### PR TITLE
Fix scope gesture transition issues

### DIFF
--- a/FSCalendar/FSCalendar.h
+++ b/FSCalendar/FSCalendar.h
@@ -148,10 +148,36 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)calendarCurrentPageDidChange:(FSCalendar *)calendar;
 
+- (void)calendarScrollViewDidScroll:(UIScrollView *)scrollView;
+
+/**
+ Asks the delegate for the diameter of shape layer for a specific date.
+ Return 0 to use default calculated diameter.
+ */
+- (CGFloat)calendar:(FSCalendar *)calendar diameterForShapeLayerAtDate:(NSDate *)date;
+
+/**
+ Asks the delegate for the insets of shape layer relative to cell's content view.
+ Return UIEdgeInsetsZero to use no insets.
+ */
+- (UIEdgeInsets)calendar:(FSCalendar *)calendar insetsForShapeLayerAtDate:(NSDate *)date;
+
+/**
+ Asks the delegate for the size of header item.
+ Return CGSizeZero to use default calculated size.
+ */
+- (CGSize)calendar:(FSCalendar *)calendar sizeForHeaderItemAtSection:(NSInteger)section;
+
+/**
+ Asks the delegate for the insets of header layout.
+ Return UIEdgeInsetsZero to use no insets.
+ */
+- (UIEdgeInsets)calendar:(FSCalendar *)calendar insetsForHeaderLayoutAtSection:(NSInteger)section;
+
 @end
 
 /**
- * FSCalendarDelegateAppearance determines the fonts and colors of components in the calendar, but more specifically. Basically, if you need to make a global customization of appearance of the calendar, use FSCalendarAppearance. But if you need different appearance for different days, use FSCalendarDelegateAppearance.
+ * FSCalendarDelegateAppearance determines the fonts and colors of components in the calendar, but more specificly. Basically, if you need to make a global customization of appearance of the calendar, use FSCalendarAppearance. But if you need different appearance for different days, use FSCalendarDelegateAppearance.
  *
  * @see FSCalendarAppearance
  */
@@ -243,11 +269,6 @@ IB_DESIGNABLE
 @interface FSCalendar : UIView
 
 /**
- * The timezone of the calendar. `defaultTimeZone` by default.
- */
-@property (strong, nonatomic) NSTimeZone *timeZone;
-
-/**
  * The object that acts as the delegate of the calendar.
  */
 @property (weak, nonatomic) IBOutlet id<FSCalendarDelegate> delegate;
@@ -288,11 +309,44 @@ IB_DESIGNABLE
 @property (assign, nonatomic) FSCalendarScrollDirection scrollDirection;
 
 /**
- * The scope of calendar, change scope will trigger an inner frame change, make sure the frame has been correctly adjusted in 
+ * The scope of calendar, change scope will trigger an inner frame change, make sure the frame has been correctly adjusted in
  *
  *    - (void)calendar:(FSCalendar *)calendar boundingRectWillChange:(CGRect)bounds animated:(BOOL)animated;
  */
 @property (assign, nonatomic) FSCalendarScope scope;
+
+/**
+ * The diameter of shape layer in calendar cell. Use this to control the size of date background circle.
+ *
+ * e.g. To set shape layer diameter to 30pt:
+ *
+ *    calendar.shapeLayerDiameter = 30.0;
+ *
+ * Default is 0 (auto calculated based on cell size).
+ */
+@property (assign, nonatomic) CGFloat shapeLayerDiameter;
+
+/**
+ * The line spacing between rows (vertical spacing between cells).
+ *
+ * e.g. To set 10pt spacing between rows:
+ *
+ *    calendar.lineSpacing = 10.0;
+ *
+ * Default is 0.
+ */
+@property (assign, nonatomic) CGFloat lineSpacing;
+
+/**
+ * The content insets of the calendar view.
+ *
+ * e.g. To add 10pt padding around the calendar:
+ *
+ *    calendar.calendarContentInsets = UIEdgeInsetsMake(10, 10, 10, 10);
+ *
+ * Default is UIEdgeInsetsZero.
+ */
+@property (assign, nonatomic) UIEdgeInsets calendarContentInsets;
 
 /**
  A UIPanGestureRecognizer instance which enables the control of scope on the whole day-area. Not available if the scrollDirection is vertical.
@@ -342,6 +396,10 @@ IB_DESIGNABLE
  */
 @property (assign, nonatomic) IBInspectable CGFloat weekdayHeight;
 
+/**
+ collection的高度
+ */
+@property (assign, nonatomic) CGFloat collectionHeight;
 /**
  The weekday view of the calendar
  */
@@ -518,7 +576,7 @@ IB_DESIGNABLE
 @end
 
 
-IB_DESIGNABLE
+//IB_DESIGNABLE
 @interface FSCalendar (IBExtension)
 
 #if TARGET_INTERFACE_BUILDER

--- a/FSCalendar/FSCalendarCell.h
+++ b/FSCalendar/FSCalendarCell.h
@@ -54,6 +54,7 @@ typedef NS_ENUM(NSUInteger, FSCalendarMonthPosition);
 @property (weak, nonatomic) FSCalendar *calendar;
 @property (weak, nonatomic) FSCalendarAppearance *appearance;
 
+@property (strong, nonatomic) NSDate *date; // 当前 cell 对应的日期
 @property (strong, nonatomic) NSString *subtitle;
 @property (strong, nonatomic) UIImage  *image;
 @property (assign, nonatomic) FSCalendarMonthPosition monthPosition;

--- a/FSCalendar/FSCalendarHeaderView.m
+++ b/FSCalendar/FSCalendarHeaderView.m
@@ -282,12 +282,12 @@
 - (void)prepareLayout
 {
     [super prepareLayout];
-    
+
     self.itemSize = CGSizeMake(
                                self.collectionView.fs_width*((self.scrollDirection==UICollectionViewScrollDirectionHorizontal)?0.5:1),
                                self.collectionView.fs_height
                               );
-    
+
 }
 
 - (void)didReceiveOrientationChangeNotification:(NSNotification *)notificatino


### PR DESCRIPTION
Fixed two critical issues in scope gesture handling （#1320）:

1. Fixed continuous expand/collapse during single swipe gesture
   - Removed ABS() from translation in scopeTransitionDidUpdate
   - Properly handle swipe direction based on target scope
   - Prevent gesture from reversing direction mid-swipe

2. Fixed incorrect position judgment when gesture ends
   - Changed logic to primarily use progress (>0.5) for decision
   - Added velocity consideration for fast swipes
   - Prevent unexpected revert when user has swiped far enough